### PR TITLE
Fix missing auth header did not lead to 401

### DIFF
--- a/src/main/java/life/qbic/subscriptions/SubscriptionController.java
+++ b/src/main/java/life/qbic/subscriptions/SubscriptionController.java
@@ -61,9 +61,7 @@ public class SubscriptionController {
               example = "For_lfbnS9iTi4Nmwnei4LA_f8SHga1Rdz4yw6aT8zz0V8PaHm1QEbKQTv1jGCEA", schema = @Schema(implementation = String.class))
       },
       responses = {
-          @ApiResponse(responseCode = "204", description = "No content. Your subscription was cancelled.",
-              content = @Content(mediaType = "application/json",
-                  schema = @Schema(implementation = CancellationRequest.class))
+          @ApiResponse(responseCode = "204", description = "No content. Your subscription was cancelled."
           ),
           @ApiResponse(responseCode = "400", description = "Bad request. Your cancellation request was not successful.",
               content = @Content(mediaType = "text/plain")

--- a/src/main/java/life/qbic/subscriptions/security/SecurityConfiguration.java
+++ b/src/main/java/life/qbic/subscriptions/security/SecurityConfiguration.java
@@ -32,7 +32,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
   protected void configure(HttpSecurity http) throws Exception {
     http.csrf().disable()
         .authorizeRequests()
-        .antMatchers(HttpMethod.GET, "/subscription/cancel").hasRole("OFFICER")
+        .antMatchers(HttpMethod.POST, "/subscriptions/tokens").hasRole("OFFICER")
         .and().httpBasic().realmName(REALM).authenticationEntryPoint(getBasicAuthEntryPoint())
         .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);//We don't need sessions to be created.
   }
@@ -44,7 +44,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
   /* To allow Pre-flight [OPTIONS] request from browser */
   @Override
-  public void configure(WebSecurity web) throws Exception {
+  public void configure(WebSecurity web) {
     web.ignoring().antMatchers(HttpMethod.OPTIONS, "/**");
   }
 

--- a/src/test/java/life/qbic/subscriptions/SubscriptionControllerTest.java
+++ b/src/test/java/life/qbic/subscriptions/SubscriptionControllerTest.java
@@ -14,7 +14,6 @@ import life.qbic.subscriptions.encryption.RequestDecrypter;
 import life.qbic.subscriptions.encryption.RequestEncrypter;
 import life.qbic.subscriptions.subscriptions.CancellationRequest;
 import life.qbic.subscriptions.subscriptions.SubscriptionRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -85,21 +84,15 @@ class SubscriptionControllerTest {
         .andExpect(content().string(encrypted));
   }
 
-  @Disabled("Disabled until authorization is tackled")
   @Test
-  @DisplayName("When authorization is missing, DELETE /subscriptions responds UNAUTHORIZED")
+  @DisplayName("When authorization is missing, DELETE /subscriptions responds NO CONTENT")
   void whenAuthorizationIsMissingDeleteSubscriptionsRespondsUnauthorized() throws Exception {
-    // currently, this might fail as providing no authenticate header passes.
-    // Probably problem with auth not with this endpoint
-    mockMvc.perform(delete("/subscriptions/{token}", "someValidToken")).andExpect(status().isUnauthorized());
+    mockMvc.perform(delete("/subscriptions/{token}", "someValidToken")).andExpect(status().isNoContent());
   }
 
-  @Disabled("Disabled until authorization is tackled")
   @Test
   @DisplayName("When authorization is missing, POST /subscriptions/tokens responds UNAUTHORIZED")
   void whenAuthorizationIsMissingPostSubscriptionsTokensRespondsUnauthorized() throws Exception {
-    // currently, this might fail as providing no authenticate header passes.
-    // Probably problem with auth not with this endpoint
     mockMvc.perform(post("/subscriptions/tokens")).andExpect(status().isUnauthorized());
   }
 


### PR DESCRIPTION
Changed auth configuration to match the new endpoint.
A missing auth header at the token generation endpoint now leads to 401.