### PR TITLE
Introduce correct naming for person id

### DIFF
--- a/src/main/java/life/qbic/subscriptions/subscriptions/entities/Person.java
+++ b/src/main/java/life/qbic/subscriptions/subscriptions/entities/Person.java
@@ -42,7 +42,7 @@ public class Person {
   Integer active;
 
   @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "person_id")
   List<Subscription> subscriptions;
 
   public Person() {

--- a/src/main/java/life/qbic/subscriptions/subscriptions/entities/Subscription.java
+++ b/src/main/java/life/qbic/subscriptions/subscriptions/entities/Subscription.java
@@ -29,7 +29,7 @@ public class Subscription {
       fetch = FetchType.LAZY,
       cascade = {CascadeType.DETACH, CascadeType.MERGE,
           CascadeType.REFRESH, CascadeType.PERSIST})
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "person_id")
   private Person person;
 
   public Subscription() {}


### PR DESCRIPTION
The usage of the term "user_id" in the context of subscriptions is wrong, because our domain
model says: A PERSON has one or more subscriptions. So the name is irritating.